### PR TITLE
msl: improve binding matching

### DIFF
--- a/src/shader/AstGen.zig
+++ b/src/shader/AstGen.zig
@@ -70,10 +70,6 @@ pub fn genTranslationUnit(astgen: *AstGen) !RefIndex {
         var global = root_scope.decls.get(node).? catch continue;
         global = switch (astgen.tree.nodeTag(node)) {
             .@"fn" => blk: {
-                // TODO(ali): with aftersun we hit this case, continue works here but unsure if that is correct.
-                // At the very least, the assert is wrong?
-                if (global != .none) continue;
-                // std.debug.assert(global == .none);
                 break :blk astgen.genFn(root_scope, node, false) catch |err| switch (err) {
                     error.Skiped => continue,
                     else => |e| e,

--- a/src/shader/AstGen.zig
+++ b/src/shader/AstGen.zig
@@ -70,7 +70,10 @@ pub fn genTranslationUnit(astgen: *AstGen) !RefIndex {
         var global = root_scope.decls.get(node).? catch continue;
         global = switch (astgen.tree.nodeTag(node)) {
             .@"fn" => blk: {
-                std.debug.assert(global == .none);
+                // TODO(ali): with aftersun we hit this case, continue works here but unsure if that is correct.
+                // At the very least, the assert is wrong?
+                if (global != .none) continue;
+                // std.debug.assert(global == .none);
                 break :blk astgen.genFn(root_scope, node, false) catch |err| switch (err) {
                     error.Skiped => continue,
                     else => |e| e,

--- a/src/shader/CodeGen.zig
+++ b/src/shader/CodeGen.zig
@@ -153,7 +153,7 @@ pub fn generate(
     return switch (out_lang) {
         .spirv => try genSpirv(allocator, air, debug_info),
         .hlsl => try genHlsl(allocator, air, debug_info),
-        .msl => try genMsl(allocator, air, debug_info, entrypoint, bindings, label orelse "<ShaderModule label not specified>"),
+        .msl => try genMsl(allocator, air, debug_info, entrypoint.?, bindings, label orelse "<ShaderModule label not specified>"),
         .glsl => try genGlsl(allocator, air, debug_info, entrypoint, bindings),
     };
 }

--- a/src/shader/CodeGen.zig
+++ b/src/shader/CodeGen.zig
@@ -153,7 +153,7 @@ pub fn generate(
     return switch (out_lang) {
         .spirv => try genSpirv(allocator, air, debug_info),
         .hlsl => try genHlsl(allocator, air, debug_info),
-        .msl => try genMsl(allocator, air, debug_info, entrypoint.?, bindings, label orelse "<ShaderModule label not specified>"),
+        .msl => try genMsl(allocator, air, debug_info, entrypoint, bindings, label orelse "<ShaderModule label not specified>"),
         .glsl => try genGlsl(allocator, air, debug_info, entrypoint, bindings),
     };
 }

--- a/src/shader/codegen/glsl.zig
+++ b/src/shader/codegen/glsl.zig
@@ -36,7 +36,7 @@ pub fn gen(
         .bindings = bindings orelse &.{},
     };
     defer {
-        glsl.storage.deinit(allocator);
+        storage.deinit(allocator);
     }
 
     try glsl.writeAll("#version 450\n\n");


### PR DESCRIPTION
After this PR, all `examples/sysgpu` run under Metal, as well as foxxne's Aftersun game.

`zig build test` has a lot of GLSL test failures still, @alichraghi can you take a look? They are all like this:

```
error: 'test.vertexWriteGBuffers' failed: /Volumes/data/aftersun/mach-sysgpu/src/shader/codegen/glsl.zig:254:48: 0x1044c2f9f in emitGlobalVar (sysgpu-tests)
    const slot = glsl.bindings.get(key) orelse return error.NoBinding;
                                               ^
```

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.